### PR TITLE
Broken ethereum.org link

### DIFF
--- a/source/includes/architecture.mdown
+++ b/source/includes/architecture.mdown
@@ -58,7 +58,7 @@ to the policies must be handled directly off-chain by the two parties.
 
 ### Ethereum
 
-[Learn more about Ethereum](https://https://www.ethereum.org/)
+[Learn more about Ethereum](https://ethereum.org/)
 
 ### IPFS
 


### PR DESCRIPTION
Changed link from 'https://https://www.ethereum.org/' to 'https://ethereum.org/'

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->