### PR TITLE
 Basic Listings API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ These docs are very much a work in progress, but you can view them live at:
 
 Contributions welcome!
 
-Credits and detailed documentation on how to use Slate can be found at:
+
+## Contributing
+
+Once you have cloned this repo, just run: 
+
+   bundle install
+   bundle exec middleman server
+   
+Credits and detailed documentation on how to use the Slate documentation system can be found at:
 
 [https://github.com/lord/slate](https://github.com/lord/slate)

--- a/source/includes/_tbd.mdown
+++ b/source/includes/_tbd.mdown
@@ -40,13 +40,9 @@ String
 
 # Getting help
 
-## Slack
+## Discord
 
-Our team collaboration is done in public and our company Slack is open to all. If you have questions or need help getting started, our Slack channel is a great place to get assistance from our team of engineers and developers.
-
-[Request an invite to join the Origin Protocol Slack](http://slack.originprotocol.com)
-
-Once inside, find us in one of the `eng` channels.
+Our team collaboration is done in public and our company Discord is open to all. If you have questions or need help getting started, our [Discord #engineering channel](https://www.originprotocol.com/discord) is a great place to get assistance from our team of engineers and developers.
 
 ## Email
 
@@ -120,7 +116,7 @@ Origin is just as much about community as it is about our technology.
 
 We need constant help in improving our documentation, building new tools to interface with our platform, spreading the word to new users, helping new users getting setup and much more.
 
-Please get in touch if you would like to help out. Our `community` channel on [Slack](#slack) is a great place to share ideas and volunteer to help.
+Please get in touch if you would like to help out. Our `general` channel on [Discord](#discord) is a great place to share ideas and volunteer to help.
 
 ### Full Time Positions
 
@@ -128,4 +124,4 @@ Origin occasionally hires developers for part time or full time positions.
 
 We have a strong preference for hiring people who have already started contributing to the project. If you want a full time position on our team, your best shot is to engage with our team and start contributing code. It is very unlikely that we would offer you a full time position on our engineering team unless you've had at least a couple approved pull requests first. 
 
-If you are interested, check out [the Origin Protocol job listings](https://angel.co/originprotocol/jobs). If you'd like to help in other ways, propose your ideas on the [Origin Slack](#slack).
+If you are interested, check out [the Origin Protocol job listings](https://angel.co/originprotocol/jobs). If you'd like to help in other ways, propose your ideas on the [Origin Discord](#discord).

--- a/source/includes/_tbd.mdown
+++ b/source/includes/_tbd.mdown
@@ -50,12 +50,17 @@ You can also reach us by email at [support@originprotocol.com](mailto:support@or
 
 # Contributing
 
-Want to hack on Origin? Awesome! Here are instructions to get you started.
-They are not perfect yet. Please let us know what feels wrong or incomplete.
+Want to hack on Origin? Awesome!
 
 Origin is an Open Source project and we welcome contributions of all sorts.
 There are many ways to help, from reporting issues, contributing code, and
 helping us improve our community.
+
+There are three main repositories:
+
+- [Platform](https://github.com/OriginProtocol/platform) - solidity contracts and the origin.js API
+- [Demo-DApp](https://github.com/OriginProtocol/demo-dapp) - example react powered front end 
+- [Bridge Server](https://github.com/OriginProtocol/bridge-server) - python indexing and search server
 
 ### Dive Right In
 

--- a/source/includes/resources/listings.md
+++ b/source/includes/resources/listings.md
@@ -1,0 +1,88 @@
+# Listings
+
+A listing is an offer from a seller to sell something.
+
+It is active until there are no more units available or its expiration date is reached.
+
+## Create a Listing
+
+> To create a listing
+
+```javascript
+const listingData = {
+  name: "Kettlebell For Sale",
+  category: "Health and Beauty",
+  location: "San Fransisco, CA",
+  description:
+    "32kg gorilla kettlebell",
+  pictures: [],
+  price: 3.3
+}
+const schema = "for-sale"
+const transaction = await origin.listings.create(listingData, schema)
+await origin.contractService.waitTransactionFinished(transaction.tx)
+``` 
+
+When you create a listing, the API will create both the IPFS data and the Listing contract on the blockchain.
+
+The fields used come from the listing schema definition used.
+
+The wallet used to create the listing is used as the seller.
+
+A listing will expire 60 days after its expiration date.
+
+## Buy a Listing
+
+> To buy a listing
+
+```javascript
+const unitstoBuy = 2
+const amountToSend = listing.price * unitstoBuy
+const transaction = await origin.listings.buy(
+      listing.address,
+      unitstoBuy,
+      amountToSend
+    )
+await origin.contractService.waitTransactionFinished(transaction.tx)
+```
+
+Buy will create a new `Purchase` contract on the blockchain. This purchase contract will handle the rest of the transaction between the buyer and the seller.
+
+## Get a Listing
+
+> To get a listing
+
+```javascript
+const listing = await origin.listings.getByIndex(1)
+// Returns 
+{
+  name: "Kettlebell For Sale",
+  category: "Health and Beauty",
+  description: "32kg gorilla kettlebell",
+  location: "San Fransisco, CA",
+  pictures: [],
+
+  address: "659cbb0e2411a44db63778987b1e22153c086a95eb6b18bdf89de078917abc63",
+  index: 1,
+  ipfsHash: "QmWZDcDq4aYGx9XmkPcx4mnKaGW2jCxf5tknrCtbfpJJFf",
+  sellerAddress: "0f62d96d6675f32685bbdb8ac13cda7c23436f63efbb9d07700d8669ff12b7c4",
+  price: 0.004,
+  unitsAvailable: 1
+}
+```
+
+Getting a listing will return the fields from the listing according to its listing schema.
+
+In addition, you'll have fields from the contract on the blockchain.
+
+## Find All Listing Indexes
+
+> To find all listing indexes
+
+```javascript
+const indexes = await origin.listings.allIds()
+// Returns 
+[0,1,2,3,4,5,...]
+```
+
+You can get a simple list of all listing indexes in the registry, which will allow you to loop through fetch information about each Listing.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2,9 +2,7 @@
 title: API Reference
 
 language_tabs: # must be one of https://git.io/vQNgJ
-  - html
   - javascript
-  - json
 
 toc_footers:
   - <a href='http://www.originprotocol.com'>Where it all begins!</a>
@@ -15,6 +13,7 @@ includes:
   - architecture
   - getting_started
   - authentication_identity
+  - resources/listings
   - listing_schemas
   - tbd
 


### PR DESCRIPTION
- Basic Listings API documentation
- Replace Slack with Discord.
- Instructions on working with the docs system.