### PR TITLE
Match fonts and colors to design palette

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -30,6 +30,7 @@ under the License.
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400,500%7CPoppins:200,300,400,500"/>
 
     <style>
       <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -23,33 +23,37 @@ under the License.
 
 // BACKGROUND COLORS
 ////////////////////
-$nav-bg: #2E3336 !default;
-$examples-bg: #2E3336 !default;
-$code-bg: #1E2224 !default;
-$code-annotation-bg: #191D1F !default;
-$nav-subitem-bg: #1E2224 !default;
-$nav-active-bg: #0F75D4 !default;
-$nav-active-parent-bg: #1E2224 !default; // parent links of the current section
+$nav-bg: #2e3f53 !default;
+$examples-bg: #2e3f53 !default;
+$code-bg: #111d28 !default;
+$code-annotation-bg: #111d28 !default;
+$nav-subitem-bg: #111d28 !default;
+$nav-active-bg: #1a82ff !default;
+$nav-active-parent-bg: #111d28 !default; // parent links of the current section
 $lang-select-border: #000 !default;
-$lang-select-bg: #1E2224 !default;
+$lang-select-bg: #111d28 !default;
 $lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
-$main-bg: #F3F7F9 !default;
-$aside-notice-bg: #8fbcd4 !default;
-$aside-warning-bg: #c97a7e !default;
-$aside-success-bg: #6ac174 !default;
-$search-notice-bg: #c97a7e !default;
+$main-bg: #ebf0f3 !default;
+$aside-notice-bg: #6e3bea !default;
+$aside-warning-bg: #ff1a1a !default;
+$aside-success-bg: #26d198 !default;
+$search-notice-bg: #ff1a1a !default;
 
 
 // TEXT COLORS
 ////////////////////
-$main-text: #333 !default; // main content text color
+$main-text: #111d28 !default; // main content text color
 $nav-text: #fff !default;
 $nav-active-text: #fff !default;
 $nav-active-parent-text: #fff !default; // parent links of the current section
 $lang-select-text: #fff !default; // color of unselected language tab text
 $lang-select-active-text: #fff !default; // color of selected language tab text
 $lang-select-pressed-text: #fff !default; // color of language tab text when mouse is pressed
+$anchor-text: $nav-active-bg !default;
+$aside-notice-text: #fff !default;
+$aside-success-text: #fff !default;
+$aside-warning-text: #fff !default;
 
 
 // SIZES
@@ -70,13 +74,14 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 // FONTS
 ////////////////////
 %default-font {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: 'Lato', 'Helvetica Neue', 'Arial', sans-serif;
   font-size: 14px;
+  font-weight: 300;
 }
 
 %header-font {
   @extend %default-font;
-  font-weight: bold;
+  font-family: 'Poppins', sans-serif;
 }
 
 %code-font {
@@ -98,6 +103,6 @@ $search-box-border-color: #666 !default;
 // These settings are probably best left alone.
 
 %break-words {
-    word-break: break-all;
-    hyphens: auto;
+  word-break: break-all;
+  hyphens: auto;
 }

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -77,7 +77,7 @@ body {
 
   a {
     text-decoration: none;
-    color: #000;
+    color: $anchor-text;
   }
 
   h1 {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -36,6 +36,11 @@ html, body {
   -webkit-text-size-adjust: none; /* Never autoresize text */
 }
 
+a {
+  color: $anchor-text;
+  font-weight: normal;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // TABLE OF CONTENTS
 ////////////////////////////////////////////////////////////////////////////////
@@ -471,13 +476,20 @@ html, body {
     margin-bottom: 1.5em;
     background: $aside-notice-bg;
     line-height: 1.6;
+    font-weight: 600;
+
+    &.notice {
+      color: $aside-notice-text;
+    }
 
     &.warning {
       background-color: $aside-warning-bg;
+      color: $aside-warning-text;
     }
 
     &.success {
       background-color: $aside-success-bg;
+      color: $aside-success-text;
     }
   }
 
@@ -545,6 +557,8 @@ html, body {
   }
 
   blockquote {
+    border-bottom: 1px solid #2e3f53;
+
     &>p {
       background-color: $code-annotation-bg;
       padding: $code-annotation-padding 2em;


### PR DESCRIPTION
This is a first pass at #7. There is some difference between the palette prescribed on Zeplin and what is actually deployed to the website. These styles are more consistent with Zeplin and the DApp. If you prefer a more exact match to the website, let me know.

Also, this does not handle print styling, which is pretty rough already. I'll put that on the back burner while I move on to other things unless it should be a priority (@wanderingstan?).

Here is a sample of the diff:

<img width="1920" alt="screen shot 2018-04-12 at 7 26 52 pm 2" src="https://user-images.githubusercontent.com/273937/38711105-4f724ccc-3e89-11e8-92e1-c98d98091676.png">