### PR TITLE
Document user identity address

### DIFF
--- a/source/includes/resources/users.md
+++ b/source/includes/resources/users.md
@@ -7,6 +7,7 @@ A user object consists of 2 properties:
 
 - `profile`: Profile information a user chooses to reveal publicly
 - `attestations`: A list of 3rd party attestations that the user has added to their identity (see [Attestation documentation](#attestation) for details)
+- `identityAddress`: Ethereum address for the identity contract
 
 ## set
 
@@ -86,7 +87,8 @@ let updatedUser = await users.get()
         claimType: 4,
         service: "twitter"
       }
-    ]
+    ],
+    identityAddress: "0x4E72770760c011647D4873f60A3CF6cDeA896CD8"
   }
 }
 ```
@@ -106,7 +108,8 @@ let anotherUser = await origin.users.get(otherUserAddress)
 // Returns (user object)
 {
   profile: {}
-  attestations: []
+  attestations: [],
+  identityAddress: ''
 }
 ```
 


### PR DESCRIPTION
This adds `identityAddress` to the documented output of the user object. This should be merged after https://github.com/OriginProtocol/origin-js/pull/188.